### PR TITLE
build: modernize Dockerfile, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gitignore
+.dockerignore
+Dockerfile
+Makefile
+README.md
+LICENSE.txt
+*.iml
+coverage.out
+coverage.html
+scripts
+examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 AS builder
-
-RUN apk --no-cache add ca-certificates
-RUN apk add --no-cache tzdata
+# syntax=docker/dockerfile:1.7
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.21 AS builder
 
 WORKDIR /app
 
-COPY go.mod ./
-COPY go.sum ./
+COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . ./
+COPY . .
+
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /kerbecs
+ENV CGO_ENABLED=0
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s -w" -o /kerbecs
 
-##
-## Deploy
-##
-FROM alpine:3.19
+FROM gcr.io/distroless/static-debian12:nonroot
 
-WORKDIR /
+LABEL org.opencontainers.image.source="https://github.com/BK1031/Kerbecs" \
+      org.opencontainers.image.description="Kerbecs API Gateway" \
+      org.opencontainers.image.licenses="MIT"
 
 COPY --from=builder /kerbecs /kerbecs
 
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
+EXPOSE 10310 10300
 
 ENTRYPOINT ["/kerbecs"]


### PR DESCRIPTION
- Bump builder base from `golang:1.24-alpine3.21` to `golang:1.25-alpine3.21` to match the `go.mod` bump that just landed (otherwise the next image build fails)
- Build with `CGO_ENABLED=0`, `-trimpath`, and `-ldflags="-s -w"` for a fully static, stripped binary
- Switch runtime base from `alpine:3.19` to `gcr.io/distroless/static-debian12:nonroot` — no shell, no package manager, runs as UID 65532 by default. Image size drops from ~25MB to **11MB** verified locally
- Default `TZ` from `America/Los_Angeles` → `UTC`; servers should default to UTC and let deployers override
- Add OCI labels (source, description, license)
- `EXPOSE 10310 10300` for documentation
- Add `.dockerignore` to keep `.git`, `.github`, `scripts`, `examples`, coverage files, and IDE state out of the build context
- No `HEALTHCHECK` in the image — distroless has no shell or curl. Orchestrators define probes via their own configuration
- Verified: `docker build` succeeds, image is 11MB, boots against `examples/minimal.yaml` with banner / config-loaded / both listeners up