### PR TITLE
feat: hot-reload kerbecs.yaml on file change

### DIFF
--- a/config/watcher.go
+++ b/config/watcher.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// debounce is how long to wait after the last filesystem event before firing
+// the callback. Editors and atomic-write tools fire several events for a
+// single logical save (write + rename + chmod), so we coalesce them.
+const debounce = 100 * time.Millisecond
+
+// Watcher invokes onChange whenever the config file at path is modified.
+//
+// We watch the parent directory rather than the file itself so editor
+// save-via-rename and Kubernetes ConfigMap symlink swaps both fire correctly
+// — fsnotify on a single file misses both of those patterns.
+type Watcher struct {
+	path     string
+	onChange func()
+}
+
+// NewWatcher returns a Watcher that fires onChange when path is modified.
+// onChange runs synchronously on the watcher's goroutine; it should not
+// block for long.
+func NewWatcher(path string, onChange func()) *Watcher {
+	return &Watcher{path: path, onChange: onChange}
+}
+
+// Start blocks until ctx is canceled. Errors during startup are returned;
+// errors during operation are logged via the callback returning normally
+// (caller decides how to handle parse failures).
+func (w *Watcher) Start(ctx context.Context) error {
+	dir := filepath.Dir(w.path)
+	target, err := filepath.Abs(w.path)
+	if err != nil {
+		return fmt.Errorf("resolve config path: %w", err)
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+	defer fsw.Close()
+
+	if err := fsw.Add(dir); err != nil {
+		return fmt.Errorf("watch %s: %w", dir, err)
+	}
+
+	var timer *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case event, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+			eventPath, _ := filepath.Abs(event.Name)
+			// Care about events on our exact file, plus K8s ConfigMap
+			// re-mounts (the symlinked '..data' directory swap).
+			if eventPath != target && filepath.Base(event.Name) != "..data" {
+				continue
+			}
+			if timer == nil {
+				timer = time.AfterFunc(debounce, w.onChange)
+			} else {
+				timer.Reset(debounce)
+			}
+
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			return fmt.Errorf("fsnotify error: %w", err)
+		}
+	}
+}

--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatcher_FiresOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kerbecs.yaml")
+	if err := os.WriteFile(path, []byte("gateway: { name: a }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Int32
+	w := NewWatcher(path, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	// Give the watcher a moment to install the inotify/kqueue handle before
+	// we make any changes.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := os.WriteFile(path, []byte("gateway: { name: b }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait long enough for debounce + a margin.
+	deadline := time.Now().Add(2 * time.Second)
+	for fired.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if fired.Load() == 0 {
+		t.Fatal("expected onChange to fire after file write")
+	}
+}
+
+func TestWatcher_DebouncesBurst(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kerbecs.yaml")
+	if err := os.WriteFile(path, []byte("v: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Int32
+	w := NewWatcher(path, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Five rapid writes within the debounce window should produce one fire.
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(path, []byte{byte('0' + i), '\n'}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait past the debounce window.
+	time.Sleep(300 * time.Millisecond)
+
+	got := fired.Load()
+	if got != 1 {
+		t.Errorf("expected 1 fire after burst, got %d", got)
+	}
+}
+
+func TestWatcher_IgnoresUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kerbecs.yaml")
+	other := filepath.Join(dir, "other.txt")
+	if err := os.WriteFile(path, []byte("v: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Int32
+	w := NewWatcher(path, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Touch an unrelated file in the same directory.
+	if err := os.WriteFile(other, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	if fired.Load() != 0 {
+		t.Errorf("expected no fires for unrelated file, got %d", fired.Load())
+	}
+}

--- a/gateway/api.go
+++ b/gateway/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"kerbecs/config"
-	"kerbecs/router"
 	"kerbecs/pkg/logger"
 	"net/http"
 	"time"
@@ -26,11 +25,13 @@ type ListenerConfig struct {
 }
 
 // Serve starts the gateway HTTP listener and blocks until ctx is canceled, at
-// which point it drains in-flight requests up to shutdownTimeout.
-func Serve(ctx context.Context, listener ListenerConfig, handler HandlerConfig, rt *router.Router) error {
+// which point it drains in-flight requests up to shutdownTimeout. The state
+// pointer is read once per request, so atomic updates to the route table
+// (hot reload) are picked up without restarting the listener.
+func Serve(ctx context.Context, listener ListenerConfig, handler HandlerConfig, state *StatePointer) error {
 	srv := &http.Server{
 		Addr:    ":" + listener.Port,
-		Handler: SetupRouter(listener, handler, rt),
+		Handler: SetupRouter(listener, handler, state),
 	}
 
 	errCh := make(chan error, 1)
@@ -57,7 +58,7 @@ func Serve(ctx context.Context, listener ListenerConfig, handler HandlerConfig, 
 	}
 }
 
-func SetupRouter(listener ListenerConfig, handler HandlerConfig, rt *router.Router) *gin.Engine {
+func SetupRouter(listener ListenerConfig, handler HandlerConfig, state *StatePointer) *gin.Engine {
 	if listener.Env == "PROD" {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -68,7 +69,7 @@ func SetupRouter(listener ListenerConfig, handler HandlerConfig, rt *router.Rout
 	r.Use(ProxyRequestLogger())
 	r.Use(ProxyAuthMiddleware())
 	r.Use(ProxyResponseLogger())
-	r.Any("/*path", NewProxyHandler(handler, rt))
+	r.Any("/*path", NewProxyHandler(handler, state))
 	return r
 }
 

--- a/gateway/proxy.go
+++ b/gateway/proxy.go
@@ -72,21 +72,25 @@ func ProxyResponseLogger() gin.HandlerFunc {
 	}
 }
 
-// NewProxyHandler returns a gin handler that resolves routes via the given
-// router and proxies matched requests to the route's upstream. If the matched
-// route has envelope: default, the upstream response is buffered and wrapped
-// in the Kerbecs envelope. passthrough routes stream unchanged.
+// NewProxyHandler returns a gin handler that resolves routes via the live
+// state pointer and proxies matched requests to the route's upstream. The
+// state is loaded once per request so each request sees a consistent view of
+// (router, transports) even across hot reloads.
+//
+// If the matched route has envelope: default, the upstream response is
+// buffered and wrapped in the Kerbecs envelope. passthrough routes stream
+// unchanged.
 //
 // Pre-match errors (no route found) are returned as plain JSON without an
 // envelope, since the envelope is a property of a matched route.
-func NewProxyHandler(cfg HandlerConfig, rt *router.Router) gin.HandlerFunc {
+func NewProxyHandler(cfg HandlerConfig, state *StatePointer) gin.HandlerFunc {
 	gateway := cfg.formattedGateway()
-	transports := buildTransportCache(rt)
 
 	return func(c *gin.Context) {
+		live := state.Load()
 		start := requestStart(c)
 
-		match := rt.Find(c.Request.Method, c.Request.Host, c.Request.URL.Path)
+		match := live.Router.Find(c.Request.Method, c.Request.Host, c.Request.URL.Path)
 		if match == nil {
 			c.JSON(http.StatusNotFound, gin.H{
 				"message": "No route configured for " + c.Request.Method + " " + c.Request.URL.String(),
@@ -135,7 +139,7 @@ func NewProxyHandler(cfg HandlerConfig, rt *router.Router) gin.HandlerFunc {
 		logger.SugarLogger.Infof("PROXY TO: %s @ %s%s", service, target.String(), c.Request.URL.Path)
 
 		proxy := httputil.NewSingleHostReverseProxy(target)
-		if tr, ok := transports[up.Name]; ok {
+		if tr, ok := live.Transports[up.Name]; ok {
 			proxy.Transport = tr
 		}
 		if match.Route.Envelope == provider.EnvelopeDefault {

--- a/gateway/state.go
+++ b/gateway/state.go
@@ -1,0 +1,30 @@
+package gateway
+
+import (
+	"kerbecs/router"
+	"net/http"
+	"sync/atomic"
+)
+
+// LiveState is the atomically-swappable runtime data the proxy handler reads
+// per request: the route table and the per-upstream HTTP transport cache.
+// Both pieces must be updated together so a request never sees a route from
+// generation N alongside transports from generation N-1.
+type LiveState struct {
+	Router     *router.Router
+	Transports map[string]*http.Transport
+}
+
+// BuildState constructs a LiveState from a router. Transport cache is built
+// from the unique upstreams in the router's current route table.
+func BuildState(rt *router.Router) *LiveState {
+	transports := map[string]*http.Transport{}
+	for _, up := range rt.Upstreams() {
+		transports[up.Name] = buildTransport(up.Timeouts)
+	}
+	return &LiveState{Router: rt, Transports: transports}
+}
+
+// StatePointer is the atomic pointer the listener reads from. main owns the
+// pointer; the watcher updates it on config reload.
+type StatePointer = atomic.Pointer[LiveState]

--- a/gateway/transport.go
+++ b/gateway/transport.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"kerbecs/provider"
-	"kerbecs/router"
 	"net"
 	"net/http"
 	"time"
@@ -16,17 +15,6 @@ const (
 	defaultHeadersTimeout = 30 * time.Second
 	defaultIdleConnTimeout = 90 * time.Second
 )
-
-// buildTransportCache returns a map from upstream name to a dedicated
-// *http.Transport, so each upstream gets its own connection pool and timeout
-// profile.
-func buildTransportCache(rt *router.Router) map[string]*http.Transport {
-	out := map[string]*http.Transport{}
-	for _, up := range rt.Upstreams() {
-		out[up.Name] = buildTransport(up.Timeouts)
-	}
-	return out
-}
 
 func buildTransport(t provider.Timeouts) *http.Transport {
 	dialer := &net.Dialer{

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/cors v1.7.2 h1:oLDHxdg8W/XDoN/8zamqk/Drgt4oVZDvaV0YmvVICQw=

--- a/main.go
+++ b/main.go
@@ -16,9 +16,6 @@ import (
 )
 
 func main() {
-	// Bootstrap the logger from the ENV variable so config-load errors below
-	// can be reported before the YAML is parsed. Once the file is loaded,
-	// file.Gateway.Env is the authoritative source for everything else.
 	logger.Init(os.Getenv("ENV") == "PROD")
 	defer logger.Logger.Sync()
 
@@ -34,16 +31,12 @@ func main() {
 
 	config.PrintStartupBanner(file.Gateway.Env)
 
-	static, err := provider.NewStatic(file)
+	state, err := buildLiveState(file)
 	if err != nil {
-		logger.SugarLogger.Fatalf("Failed to build static provider: %v", err)
+		logger.SugarLogger.Fatalf("Failed to build initial state: %v", err)
 	}
-	logger.SugarLogger.Infof("Static provider loaded %d route(s)", len(static.Routes()))
-
-	rt, err := router.New(static)
-	if err != nil {
-		logger.SugarLogger.Fatalf("Failed to build router: %v", err)
-	}
+	statePtr := &gateway.StatePointer{}
+	statePtr.Store(state)
 
 	handlerCfg := gateway.HandlerConfig{
 		GatewayName:    firstNonEmpty(file.Gateway.Name, config.Name),
@@ -65,14 +58,63 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// Optional config-file watcher: when providers.static.watch is true,
+	// re-read the YAML on changes and atomically swap the live state.
+	if file.Providers.Static.Watch {
+		w := config.NewWatcher(path, func() { reload(path, statePtr) })
+		go func() {
+			if err := w.Start(ctx); err != nil {
+				logger.SugarLogger.Errorf("config watcher: %v", err)
+			}
+		}()
+		logger.SugarLogger.Infof("watching %s for changes", path)
+	}
+
 	var eg errgroup.Group
 	eg.Go(func() error { return admin.Serve(ctx, adminCfg) })
-	eg.Go(func() error { return gateway.Serve(ctx, listenerCfg, handlerCfg, rt) })
+	eg.Go(func() error { return gateway.Serve(ctx, listenerCfg, handlerCfg, statePtr) })
 
 	if err := eg.Wait(); err != nil {
 		logger.SugarLogger.Fatalf("server error: %v", err)
 	}
 	logger.SugarLogger.Infoln("shutdown complete")
+}
+
+// buildLiveState reads the parsed config and constructs the runtime state
+// (provider, router, transport cache) that the proxy handler consumes.
+func buildLiveState(file *config.File) (*gateway.LiveState, error) {
+	static, err := provider.NewStatic(file)
+	if err != nil {
+		return nil, err
+	}
+	rt, err := router.New(static)
+	if err != nil {
+		return nil, err
+	}
+	logger.SugarLogger.Infof("Static provider loaded %d route(s)", len(static.Routes()))
+	return gateway.BuildState(rt), nil
+}
+
+// reload re-reads the config file and atomically swaps the live state.
+// On any failure, the existing state stays in place — bad config never
+// brings the gateway down.
+func reload(path string, statePtr *gateway.StatePointer) {
+	logger.SugarLogger.Infof("config change detected, reloading %s", path)
+	file, err := config.LoadFile(path)
+	if err != nil {
+		logger.SugarLogger.Errorf("reload: parse failed, keeping previous config: %v", err)
+		return
+	}
+	for _, w := range config.ApplyDefaults(file) {
+		logger.SugarLogger.Warnln(w)
+	}
+	newState, err := buildLiveState(file)
+	if err != nil {
+		logger.SugarLogger.Errorf("reload: build failed, keeping previous config: %v", err)
+		return
+	}
+	statePtr.Store(newState)
+	logger.SugarLogger.Infoln("config reload complete")
 }
 
 func firstNonEmpty(values ...string) string {


### PR DESCRIPTION
- Opt-in file watcher driven by `providers.static.watch: true` (the field was parsed-but-unused before this PR)
- Watches the parent directory via `fsnotify` so editor save-via-rename and (later) K8s ConfigMap symlink swaps both fire
- 100ms debounce so a single save doesn't trigger multiple reloads
- New `gateway.LiveState` bundles router + per-upstream transports; proxy handler reads via `atomic.Pointer[LiveState]` once per request — consistent snapshot across reloads, no locks on the hot path
- Reload pipeline rebuilds provider → router → transports → atomic store; on any parse or build failure, keeps the previous state and logs loudly (bad config never brings the gateway down)
- Replaces the previous build-once transport cache
- Verified end-to-end: edits flip routes atomically; new routes appear without restart; existing routes unaffected by partial changes; broken YAML triggers an error log and the old config keeps serving
- This atomic-swap pipeline is also the foundation for the upcoming KubernetesProvider — once it can push RouteUpdates, the only thing left is wiring its source into the same reload path