### PR TITLE
feat(config): add polling config watcher alongside file events

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,42 @@ All other "well-known" names (`PORT`, `ADMIN_PORT`, `KERBECS_USER`,
 `${VAR:default}` expansions. They have no effect unless the YAML you load
 actually references them.
 
+## Configuration reloading
+
+With `providers.static.watch: true`, Kerbecs reloads the config file on change
+and atomically swaps the live routing state — no restart, no dropped
+connections. If the new file fails to parse or build, the previous config stays
+in place and the error is logged, so a bad edit never takes the gateway down.
+When `watch` is `false` (the default), the config is read once at startup.
+
+Two reload mechanisms are available via `watch_mode`:
+
+| `watch_mode`     | How it detects changes                          | When to use it |
+|------------------|-------------------------------------------------|----------------|
+| `file` (default) | Filesystem events (`fsnotify`, inotify/kqueue). | Local files and most volume mounts. Lowest latency. |
+| `poll`           | Stats the file every `watch_interval`.          | When file events aren't delivered for the config path — some network/overlay mounts and container volume drivers never fire them. |
+
+```yaml
+providers:
+  static:
+    watch: true
+    watch_mode: file        # "file" (default) or "poll"
+
+# or, to poll instead of relying on filesystem events:
+providers:
+  static:
+    watch: true
+    watch_mode: poll
+    watch_interval: 5s      # poll period; defaults to 5s
+```
+
+Both modes are Kubernetes ConfigMap–aware: a ConfigMap update swaps the mounted
+`..data` symlink, which `file` mode observes as a directory event and `poll`
+mode detects as a change in the resolved symlink target. (This requires a
+whole-directory ConfigMap mount, not a `subPath` mount — `subPath` volumes
+don't receive updates.) An unknown `watch_mode` logs a warning and falls back
+to `file`.
+
 ## Current capabilities
 
 - HTTP/1.1 ingress; HTTP/2 upstream negotiation via `ForceAttemptHTTP2`
@@ -260,6 +296,7 @@ actually references them.
 - First-match routing with exact / prefix / regex path patterns
 - Per-route byte caps for requests and responses
 - Per-listener CORS (allowlist or wildcard, off by default)
+- Hot config reload via file events or polling, with atomic state swap
 - Graceful shutdown with in-flight drain
 - Constant-time admin auth
 
@@ -269,7 +306,6 @@ actually references them.
   JWT, rate limiting, and per-route policy are blocked on this.
 - **Active health checks.** `health_check` config is parsed but unused; dead
   instances stay in load-balancer rotation.
-- **Hot reload on config change.** Restart required.
 - **Prometheus metrics and OpenTelemetry tracing.**
 - **TLS termination** on the listener. Run behind a TLS-terminating LB.
 - **Non-static providers** (service registry, Docker labels, Kubernetes

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // ApplyDefaults fills in unset fields on a parsed File with the values the
 // gateway needs in order to boot. It returns a list of human-readable warnings
 // for defaults that represent security-relevant fallbacks (e.g. admin
@@ -26,6 +28,22 @@ func ApplyDefaults(f *File) []string {
 	if f.Listeners.Admin.Auth.Password == "" {
 		f.Listeners.Admin.Auth.Password = "admin"
 		warnings = append(warnings, "admin password not set in config; defaulting to \"admin\" — DO NOT USE IN PRODUCTION")
+	}
+
+	if f.Providers.Static.Watch {
+		switch f.Providers.Static.WatchMode {
+		case "", WatchModeFile:
+			f.Providers.Static.WatchMode = WatchModeFile
+		case WatchModePoll:
+			if f.Providers.Static.WatchInterval.AsDuration() <= 0 {
+				f.Providers.Static.WatchInterval = Duration(defaultPollInterval)
+			}
+		default:
+			warnings = append(warnings, fmt.Sprintf(
+				"unknown providers.static.watch_mode %q; falling back to %q",
+				f.Providers.Static.WatchMode, WatchModeFile))
+			f.Providers.Static.WatchMode = WatchModeFile
+		}
 	}
 
 	return warnings

--- a/config/poll_watcher.go
+++ b/config/poll_watcher.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// defaultPollInterval is used when WatchModePoll is selected without an
+// explicit watch_interval.
+const defaultPollInterval = 5 * time.Second
+
+// PollWatcher invokes onChange when the config file at path changes, detected
+// by stat-ing the file on a fixed interval rather than subscribing to
+// filesystem events. It's the portable fallback for environments where
+// inotify/kqueue events aren't delivered for the config path (some network
+// and container volume mounts).
+type PollWatcher struct {
+	path     string
+	interval time.Duration
+	onChange func()
+}
+
+// NewPollWatcher returns a PollWatcher. A non-positive interval falls back to
+// defaultPollInterval. onChange runs synchronously on the watcher's goroutine
+// and should not block for long.
+func NewPollWatcher(path string, interval time.Duration, onChange func()) *PollWatcher {
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	return &PollWatcher{path: path, interval: interval, onChange: onChange}
+}
+
+// Start blocks until ctx is canceled, firing onChange whenever the file's
+// fingerprint changes between polls.
+func (w *PollWatcher) Start(ctx context.Context) error {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	last, haveLast := fingerprint(w.path)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			cur, ok := fingerprint(w.path)
+			if !ok {
+				// Stat failed — likely a transient state mid-swap (e.g. a
+				// Kubernetes ConfigMap ..data rename). Keep the previous
+				// fingerprint so the next successful poll still detects the
+				// change.
+				continue
+			}
+			if !haveLast {
+				last, haveLast = cur, true
+				continue
+			}
+			if !cur.equal(last) {
+				last = cur
+				w.onChange()
+			}
+		}
+	}
+}
+
+// fileFingerprint identifies a version of the config file. The resolved
+// symlink target is included because a Kubernetes ConfigMap update swaps the
+// ..data symlink to a freshly named directory — that target path changes even
+// in the rare case where size and mtime collide.
+type fileFingerprint struct {
+	resolved string
+	size     int64
+	modTime  time.Time
+}
+
+func (a fileFingerprint) equal(b fileFingerprint) bool {
+	return a.resolved == b.resolved && a.size == b.size && a.modTime.Equal(b.modTime)
+}
+
+// fingerprint stats path (following symlinks) and returns its fingerprint.
+// The bool is false when the file can't be stat'd.
+func fingerprint(path string) (fileFingerprint, bool) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		// Not a symlink (or broken mid-swap) — fall back to the raw path so a
+		// plain regular file still fingerprints on size + mtime.
+		resolved = path
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileFingerprint{}, false
+	}
+	return fileFingerprint{resolved: resolved, size: info.Size(), modTime: info.ModTime()}, true
+}

--- a/config/poll_watcher_test.go
+++ b/config/poll_watcher_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPollWatcher_FiresOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kerbecs.yaml")
+	if err := os.WriteFile(path, []byte("v: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Int32
+	w := NewPollWatcher(path, 20*time.Millisecond, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	// Let the watcher capture the initial fingerprint before we change it.
+	time.Sleep(50 * time.Millisecond)
+
+	// Different size and content so the change is detected regardless of mtime
+	// granularity on the test filesystem.
+	if err := os.WriteFile(path, []byte("v: 123456789\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for fired.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if fired.Load() == 0 {
+		t.Fatal("expected onChange to fire after file write")
+	}
+}
+
+func TestPollWatcher_IgnoresUnrelatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kerbecs.yaml")
+	other := filepath.Join(dir, "other.txt")
+	if err := os.WriteFile(path, []byte("v: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Int32
+	w := NewPollWatcher(path, 20*time.Millisecond, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := os.WriteFile(other, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if fired.Load() != 0 {
+		t.Errorf("expected no fires for unrelated file, got %d", fired.Load())
+	}
+}
+
+// A ConfigMap update swaps a ..data symlink to a new target directory. The
+// fingerprint includes the resolved path, so it should fire even if the new
+// file's size and mtime happen to match the old one.
+func TestPollWatcher_DetectsSymlinkSwap(t *testing.T) {
+	dir := t.TempDir()
+	dataA := filepath.Join(dir, "a")
+	dataB := filepath.Join(dir, "b")
+	for _, d := range []string{dataA, dataB} {
+		if err := os.Mkdir(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "kerbecs.yaml"), []byte("v: same\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	link := filepath.Join(dir, "..data")
+	if err := os.Symlink(dataA, link); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(link, "kerbecs.yaml")
+
+	var fired atomic.Int32
+	w := NewPollWatcher(path, 20*time.Millisecond, func() { fired.Add(1) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Atomically repoint the symlink at the other directory (rename-over).
+	tmp := filepath.Join(dir, ".data-tmp")
+	if err := os.Symlink(dataB, tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, link); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for fired.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if fired.Load() == 0 {
+		t.Fatal("expected onChange to fire after symlink swap")
+	}
+}
+
+func TestNewConfigWatcher_SelectsMode(t *testing.T) {
+	noop := func() {}
+	if _, ok := NewConfigWatcher(StaticProviderConfig{Watch: true, WatchMode: WatchModePoll, WatchInterval: Duration(time.Second)}, "kerbecs.yaml", noop).(*PollWatcher); !ok {
+		t.Error("expected *PollWatcher for watch_mode: poll")
+	}
+	if _, ok := NewConfigWatcher(StaticProviderConfig{Watch: true, WatchMode: WatchModeFile}, "kerbecs.yaml", noop).(*Watcher); !ok {
+		t.Error("expected *Watcher for watch_mode: file")
+	}
+	if _, ok := NewConfigWatcher(StaticProviderConfig{Watch: true}, "kerbecs.yaml", noop).(*Watcher); !ok {
+		t.Error("expected *Watcher when watch_mode is unset")
+	}
+}

--- a/config/schema.go
+++ b/config/schema.go
@@ -43,7 +43,7 @@ type ListenersSection struct {
 }
 
 type GatewayListener struct {
-	Port string     `yaml:"port"`
+	Port string      `yaml:"port"`
 	CORS *CORSConfig `yaml:"cors,omitempty"`
 }
 
@@ -74,8 +74,29 @@ type ProvidersSection struct {
 	// Rincon and other providers added in later phases.
 }
 
+// Watch reload mechanisms for the static provider.
+const (
+	// WatchModeFile reloads via filesystem events (fsnotify). Low latency,
+	// but depends on inotify/kqueue delivering events for the config path —
+	// which not every filesystem does (some network and overlay mounts, and
+	// certain container volume drivers, never fire events).
+	WatchModeFile = "file"
+	// WatchModePoll reloads by stat-ing the config file on a fixed interval.
+	// Higher latency and a small constant cost, but works anywhere os.Stat
+	// does — the reliable choice when file events aren't delivered.
+	WatchModePoll = "poll"
+)
+
 type StaticProviderConfig struct {
+	// Watch enables hot-reloading the config file. When false the config is
+	// read once at startup and a restart is required to pick up changes.
 	Watch bool `yaml:"watch"`
+	// WatchMode selects the reload mechanism: "file" (default, fsnotify) or
+	// "poll". Ignored when Watch is false.
+	WatchMode string `yaml:"watch_mode,omitempty"`
+	// WatchInterval is the poll period for WatchModePoll. Defaults to 5s.
+	// Ignored for WatchModeFile.
+	WatchInterval Duration `yaml:"watch_interval,omitempty"`
 }
 
 type Upstream struct {
@@ -148,11 +169,11 @@ type ObservabilitySection struct {
 }
 
 type LoggingConfig struct {
-	Level            string   `yaml:"level"`
-	Format           string   `yaml:"format"`
-	AccessLog        bool     `yaml:"access_log"`
-	RedactHeaders    []string `yaml:"redact_headers,omitempty"`
-	MaxBodyLogBytes  int      `yaml:"max_body_log_bytes,omitempty"`
+	Level           string   `yaml:"level"`
+	Format          string   `yaml:"format"`
+	AccessLog       bool     `yaml:"access_log"`
+	RedactHeaders   []string `yaml:"redact_headers,omitempty"`
+	MaxBodyLogBytes int      `yaml:"max_body_log_bytes,omitempty"`
 }
 
 type MetricsConfig struct {

--- a/config/watcher.go
+++ b/config/watcher.go
@@ -14,6 +14,24 @@ import (
 // single logical save (write + rename + chmod), so we coalesce them.
 const debounce = 100 * time.Millisecond
 
+// FileWatcher invokes a callback when the config file changes, until its
+// context is canceled. Both the fsnotify-backed Watcher and the interval-based
+// PollWatcher implement it.
+type FileWatcher interface {
+	Start(ctx context.Context) error
+}
+
+// NewConfigWatcher builds the FileWatcher selected by the static provider
+// config — fsnotify file events (WatchModeFile, the default) or interval
+// polling (WatchModePoll). Mode and interval defaults are applied by
+// ApplyDefaults, so cfg is expected to be normalized here.
+func NewConfigWatcher(cfg StaticProviderConfig, path string, onChange func()) FileWatcher {
+	if cfg.WatchMode == WatchModePoll {
+		return NewPollWatcher(path, cfg.WatchInterval.AsDuration(), onChange)
+	}
+	return NewWatcher(path, onChange)
+}
+
 // Watcher invokes onChange whenever the config file at path is modified.
 //
 // We watch the parent directory rather than the file itself so editor

--- a/examples/kerbecs.yaml
+++ b/examples/kerbecs.yaml
@@ -27,7 +27,13 @@ listeners:
 
 providers:
   static:
+    # Hot-reload the config on change. When false (default), config is read
+    # once at startup. See the "Configuration reloading" section in the README.
     watch: false
+    # Reload mechanism when watch is true: "file" (default, fsnotify) or
+    # "poll". Use "poll" where filesystem events aren't delivered.
+    # watch_mode: poll
+    # watch_interval: 5s   # poll period (poll mode only); defaults to 5s
 
 upstreams:
   users-service:

--- a/main.go
+++ b/main.go
@@ -59,15 +59,20 @@ func main() {
 	defer cancel()
 
 	// Optional config-file watcher: when providers.static.watch is true,
-	// re-read the YAML on changes and atomically swap the live state.
+	// re-read the YAML on changes and atomically swap the live state. The
+	// reload mechanism (file events vs polling) is selected by providers.static.
 	if file.Providers.Static.Watch {
-		w := config.NewWatcher(path, func() { reload(path, statePtr) })
+		w := config.NewConfigWatcher(file.Providers.Static, path, func() { reload(path, statePtr) })
 		go func() {
 			if err := w.Start(ctx); err != nil {
 				logger.SugarLogger.Errorf("config watcher: %v", err)
 			}
 		}()
-		logger.SugarLogger.Infof("watching %s for changes", path)
+		if file.Providers.Static.WatchMode == config.WatchModePoll {
+			logger.SugarLogger.Infof("watching %s for changes (poll, every %s)", path, file.Providers.Static.WatchInterval.AsDuration())
+		} else {
+			logger.SugarLogger.Infof("watching %s for changes (file events)", path)
+		}
 	}
 
 	var eg errgroup.Group


### PR DESCRIPTION
Adds a poll-based config watcher as an alternative to the existing fsnotify file-event watcher, for environments where inotify/kqueue events aren't reliably delivered for the config path (some network/overlay mounts and certain container volume drivers).

## Config
- `providers.static.watch_mode`: `file` (default, fsnotify) or `poll`
- `providers.static.watch_interval`: poll period for poll mode (default `5s`)

`watch: true` with no `watch_mode` behaves exactly as before (file events), so this is backward compatible.

```yaml
providers:
  static:
    watch: true
    watch_mode: poll
    watch_interval: 5s
```

## Implementation
- `PollWatcher` stats the file each interval and fires `onChange` when the fingerprint (resolved symlink target + size + mtime) changes. Including the resolved target means it catches Kubernetes ConfigMap `..data` symlink swaps even in the rare case where size and mtime collide. Transient stat failures mid-swap are skipped so the next successful poll still detects the change.
- `NewConfigWatcher` factory selects file vs poll; `main.go` logs the active mode.
- Defaults normalized in `ApplyDefaults`: unknown `watch_mode` logs a warning and falls back to `file`; poll interval defaults to 5s.

## Docs
- New "Configuration reloading" section in the README documenting file vs poll, with a comparison table and the K8s ConfigMap caveat (whole-dir mount, not `subPath`).
- Removed the stale "Hot reload … Restart required" line from "Not yet supported" and added hot reload to "Current capabilities".
- Annotated `examples/kerbecs.yaml`.

## Tests
- `PollWatcher` fires on change, ignores unrelated files, and detects a symlink swap (ConfigMap simulation).
- `NewConfigWatcher` selects the right implementation per mode.
- All existing tests pass; `gofmt`/`go vet` clean.