### PR TITLE
feat(admin): registry endpoints (resolve, routes, upstreams, info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,26 @@ completion.
 A separate HTTP listener (default `:10300`) exposes Kerbecs's own endpoints.
 Basic auth is enforced for everything except `/admin-gw/ping`, and credentials
 are compared in constant time. Configure via `listeners.admin` in the YAML.
-The only built-in endpoint today is the health ping; richer admin actions
-(drain, route inspection, log-level toggle) are future work.
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /admin-gw/ping` | Liveness probe (no auth). |
+| `GET /admin-gw/resolve?path=&method=&host=` | Run the live router against `path` and return the matched upstream URL, its instances, and the rewritten path — the same decision the gateway makes. `method` defaults to `GET`. |
+| `GET /admin-gw/routes` | The live route table in precedence order (name, path, methods, host, upstream, rewrite). |
+| `GET /admin-gw/upstreams` | The distinct upstreams and their instance pools — a service-registry view. |
+| `GET /admin-gw/info` | Gateway name, version, env, and live route/upstream counts. |
+
+`resolve` lets in-cluster services treat the gateway as a service registry:
+ask "who serves `/api/core/...`?", get back the upstream URL and the path to
+send, and call it directly — no separate registry needed. All registry
+endpoints read the live router, so they reflect config hot reloads. Example:
+
+```console
+$ curl -su admin:admin '127.0.0.1:10300/admin-gw/resolve?path=/api/core/ping'
+{"matched":true,"route":"core-internal","upstream":"core",
+ "url":"http://core:9999","instances":["http://core:9999"],
+ "rewritten_path":"/core/ping"}
+```
 
 ## Environment variables
 

--- a/admin/api.go
+++ b/admin/api.go
@@ -28,10 +28,12 @@ type Config struct {
 }
 
 // Serve starts the admin HTTP listener and blocks until ctx is canceled, at
-// which point it drains in-flight requests up to shutdownTimeout.
-func Serve(ctx context.Context, cfg Config) error {
+// which point it drains in-flight requests up to shutdownTimeout. currentRouter
+// returns the live router so the registry endpoints reflect the latest config
+// after a hot reload.
+func Serve(ctx context.Context, cfg Config, currentRouter RouterFunc) error {
 	engine := SetupRouter(cfg)
-	InitializeRoutes(engine)
+	InitializeRoutes(engine, cfg, currentRouter)
 	srv := &http.Server{
 		Addr:    ":" + cfg.Port,
 		Handler: engine,
@@ -73,9 +75,13 @@ func SetupRouter(cfg Config) *gin.Engine {
 	return r
 }
 
-func InitializeRoutes(router *gin.Engine) {
+func InitializeRoutes(router *gin.Engine, cfg Config, currentRouter RouterFunc) {
 	gw := router.Group("/admin-gw", func(c *gin.Context) {})
 	gw.GET("/ping", Ping)
+	gw.GET("/resolve", Resolve(currentRouter))
+	gw.GET("/routes", Routes(currentRouter))
+	gw.GET("/upstreams", Upstreams(currentRouter))
+	gw.GET("/info", Info(cfg.Env, currentRouter))
 }
 
 func AuthMiddleware(username, password string) gin.HandlerFunc {

--- a/admin/registry.go
+++ b/admin/registry.go
@@ -1,0 +1,161 @@
+package admin
+
+import (
+	"net/http"
+
+	"kerbecs/config"
+	"kerbecs/router"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RouterFunc returns the live router. It's a func (not a *Router) so the admin
+// endpoints always read the current generation after a hot reload.
+type RouterFunc func() *router.Router
+
+type resolveResponse struct {
+	Matched       bool     `json:"matched"`
+	Route         string   `json:"route,omitempty"`
+	Upstream      string   `json:"upstream,omitempty"`
+	URL           string   `json:"url,omitempty"`
+	Instances     []string `json:"instances,omitempty"`
+	RewrittenPath string   `json:"rewritten_path,omitempty"`
+}
+
+// Resolve answers "which upstream serves this request?" for the given path
+// (and optional method/host). It runs the live router's matcher and applies the
+// route's rewrite, so callers get back the upstream URL and the path to send —
+// the same decision the gateway would make. Replaces external service-registry
+// route matching for in-cluster callers.
+//
+//	GET /admin-gw/resolve?path=/api/core/entity/123&method=GET
+//	-> { matched, route, upstream, url, instances, rewritten_path }
+func Resolve(current RouterFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		path := c.Query("path")
+		if path == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "path query parameter is required"})
+			return
+		}
+		method := c.DefaultQuery("method", http.MethodGet)
+		host := c.Query("host")
+
+		rt := current()
+		if rt == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"message": "router not ready"})
+			return
+		}
+
+		m := rt.Find(method, host, path)
+		if m == nil || m.Route == nil {
+			c.JSON(http.StatusNotFound, resolveResponse{Matched: false})
+			return
+		}
+
+		resp := resolveResponse{
+			Matched:       true,
+			Route:         m.Route.Name,
+			RewrittenPath: router.RewritePath(path, m.Route.Rewrite),
+		}
+		if up := m.Route.Upstream; up != nil {
+			resp.Upstream = up.Name
+			resp.Instances = up.Instances
+			resp.URL = up.Pick()
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+type routeInfo struct {
+	Name          string   `json:"name"`
+	Path          string   `json:"path"`
+	Methods       []string `json:"methods,omitempty"`
+	Host          string   `json:"host,omitempty"`
+	Upstream      string   `json:"upstream,omitempty"`
+	StripPrefix   string   `json:"strip_prefix,omitempty"`
+	ReplacePrefix string   `json:"replace_prefix,omitempty"`
+}
+
+// Routes lists the live route table in precedence order — the source of truth
+// callers can cache to resolve locally between refreshes.
+//
+//	GET /admin-gw/routes -> { routes: [...] }
+func Routes(current RouterFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rt := current()
+		if rt == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"message": "router not ready"})
+			return
+		}
+		out := make([]routeInfo, 0)
+		for _, r := range rt.Routes() {
+			info := routeInfo{
+				Name:    r.Name,
+				Path:    r.Match.Path,
+				Methods: r.Match.Methods,
+				Host:    r.Match.Host,
+			}
+			if r.Upstream != nil {
+				info.Upstream = r.Upstream.Name
+			}
+			if r.Rewrite != nil {
+				info.StripPrefix = r.Rewrite.StripPrefix
+				info.ReplacePrefix = r.Rewrite.ReplacePrefix
+			}
+			out = append(out, info)
+		}
+		c.JSON(http.StatusOK, gin.H{"routes": out})
+	}
+}
+
+type upstreamInfo struct {
+	Name         string   `json:"name"`
+	Version      string   `json:"version,omitempty"`
+	Instances    []string `json:"instances"`
+	LoadBalancer string   `json:"load_balancer,omitempty"`
+}
+
+// Upstreams lists the distinct upstreams referenced by the route table, with
+// their instance pools — a service-registry view of the gateway.
+//
+//	GET /admin-gw/upstreams -> { upstreams: [...] }
+func Upstreams(current RouterFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rt := current()
+		if rt == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"message": "router not ready"})
+			return
+		}
+		out := make([]upstreamInfo, 0)
+		for _, up := range rt.Upstreams() {
+			out = append(out, upstreamInfo{
+				Name:         up.Name,
+				Version:      up.Version,
+				Instances:    up.Instances,
+				LoadBalancer: up.LoadBalancer,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"upstreams": out})
+	}
+}
+
+// Info reports gateway identity and live table sizes — a quick operational
+// snapshot for dashboards and health checks.
+//
+//	GET /admin-gw/info -> { name, version, env, routes, upstreams }
+func Info(env string, current RouterFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		routes, upstreams := 0, 0
+		if rt := current(); rt != nil {
+			routes = len(rt.Routes())
+			upstreams = len(rt.Upstreams())
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"name":      config.Name,
+			"version":   config.Version,
+			"env":       env,
+			"routes":    routes,
+			"upstreams": upstreams,
+		})
+	}
+}

--- a/admin/registry_test.go
+++ b/admin/registry_test.go
@@ -1,0 +1,137 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"kerbecs/config"
+	"kerbecs/provider"
+	"kerbecs/router"
+
+	"github.com/gin-gonic/gin"
+)
+
+func testRouter(t *testing.T) *router.Router {
+	t.Helper()
+	f := &config.File{
+		Upstreams: map[string]config.Upstream{
+			"core": {Name: "core", Instances: []string{"http://core:9999"}},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "core-internal",
+				Match:    config.RouteMatch{Path: "/api/core/*"},
+				Upstream: "core",
+				Rewrite:  &config.Rewrite{StripPrefix: "/api"},
+			},
+		},
+	}
+	static, err := provider.NewStatic(f)
+	if err != nil {
+		t.Fatalf("NewStatic: %v", err)
+	}
+	rt, err := router.New(static)
+	if err != nil {
+		t.Fatalf("router.New: %v", err)
+	}
+	return rt
+}
+
+func newEngine(rt *router.Router) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	rf := RouterFunc(func() *router.Router { return rt })
+	e.GET("/admin-gw/resolve", Resolve(rf))
+	e.GET("/admin-gw/routes", Routes(rf))
+	e.GET("/admin-gw/upstreams", Upstreams(rf))
+	return e
+}
+
+func TestResolve_Match(t *testing.T) {
+	e := newEngine(testRouter(t))
+
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin-gw/resolve?path=/api/core/entity/123", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", w.Code, w.Body.String())
+	}
+	var resp resolveResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Matched || resp.Upstream != "core" {
+		t.Errorf("got %+v, want matched core", resp)
+	}
+	if resp.URL != "http://core:9999" {
+		t.Errorf("url = %q, want http://core:9999", resp.URL)
+	}
+	if resp.RewrittenPath != "/core/entity/123" {
+		t.Errorf("rewritten_path = %q, want /core/entity/123", resp.RewrittenPath)
+	}
+}
+
+func TestResolve_NoMatch(t *testing.T) {
+	e := newEngine(testRouter(t))
+
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin-gw/resolve?path=/nope", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	var resp resolveResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Matched {
+		t.Error("expected matched=false")
+	}
+}
+
+func TestResolve_MissingPath(t *testing.T) {
+	e := newEngine(testRouter(t))
+
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin-gw/resolve", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestRoutesAndUpstreams(t *testing.T) {
+	e := newEngine(testRouter(t))
+
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin-gw/routes", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("routes status = %d", w.Code)
+	}
+	var routes struct {
+		Routes []routeInfo `json:"routes"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &routes); err != nil {
+		t.Fatal(err)
+	}
+	if len(routes.Routes) != 1 || routes.Routes[0].Upstream != "core" || routes.Routes[0].StripPrefix != "/api" {
+		t.Errorf("unexpected routes: %+v", routes.Routes)
+	}
+
+	w = httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin-gw/upstreams", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("upstreams status = %d", w.Code)
+	}
+	var ups struct {
+		Upstreams []upstreamInfo `json:"upstreams"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &ups); err != nil {
+		t.Fatal(err)
+	}
+	if len(ups.Upstreams) != 1 || ups.Upstreams[0].Name != "core" || len(ups.Upstreams[0].Instances) != 1 {
+		t.Errorf("unexpected upstreams: %+v", ups.Upstreams)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -75,8 +75,17 @@ func main() {
 		}
 	}
 
+	// Admin registry endpoints read the live router so they reflect hot reloads.
+	currentRouter := func() *router.Router {
+		s := statePtr.Load()
+		if s == nil {
+			return nil
+		}
+		return s.Router
+	}
+
 	var eg errgroup.Group
-	eg.Go(func() error { return admin.Serve(ctx, adminCfg) })
+	eg.Go(func() error { return admin.Serve(ctx, adminCfg, currentRouter) })
 	eg.Go(func() error { return gateway.Serve(ctx, listenerCfg, handlerCfg, statePtr) })
 
 	if err := eg.Wait(); err != nil {

--- a/router/router.go
+++ b/router/router.go
@@ -60,6 +60,16 @@ func (r *Router) Upstreams() []*provider.Upstream {
 	return out
 }
 
+// Routes returns the matched routes in precedence order (first match wins).
+// Used by the admin API to expose the live route table.
+func (r *Router) Routes() []*provider.Route {
+	out := make([]*provider.Route, 0, len(r.routes))
+	for _, c := range r.routes {
+		out = append(out, c.route)
+	}
+	return out
+}
+
 // Find returns the first matching route, or nil if none matches.
 func (r *Router) Find(method, host, path string) *Match {
 	for _, c := range r.routes {


### PR DESCRIPTION
Expose the live router via the admin API so in-cluster services can use the gateway as a service registry — the groundwork for dropping a separate registry (rincon) in Sentinel.

## Endpoints (under `/admin-gw`, behind the existing basic auth)
| Endpoint | Description |
|----------|-------------|
| `GET /resolve?path=&method=&host=` | Runs the live router against `path`; returns matched upstream URL, instances, and the rewritten path — the same decision the gateway makes. `method` defaults to `GET`. |
| `GET /routes` | Live route table in precedence order. |
| `GET /upstreams` | Distinct upstreams + their instance pools. |
| `GET /info` | Name, version, env, route/upstream counts. |

Example:
```
$ curl -su admin:admin '127.0.0.1:10300/admin-gw/resolve?path=/api/core/ping'
{"matched":true,"route":"core-internal","upstream":"core","url":"http://core:9999","instances":["http://core:9999"],"rewritten_path":"/core/ping"}
```

## Implementation
- All endpoints read the **live** router through a `func() *router.Router` indirection, so they reflect config hot reloads.
- Added `Router.Routes()` accessor; threaded the router into `admin.Serve`.
- New `admin/registry.go` + tests building a real router from a minimal config.

## Notes
- Resolution uses the gateway's own matcher + `RewritePath`, so callers pass gateway-form paths (`/api/core/...`) and get back the upstream URL + path to send.
- `go build`/`vet`/`gofmt` clean (the one pre-existing `router_test.go` fmt nit is untouched); `go test ./...` green.